### PR TITLE
CPM-1308 Fix Page CTA check

### DIFF
--- a/wp-content/themes/bms-outcomes/page.php
+++ b/wp-content/themes/bms-outcomes/page.php
@@ -31,7 +31,7 @@ $pageCta = get_field('page_cta');
                 <?= get_field('content_body') ?>
                 <!-- WYSIWYG -->
 
-                <?php if (isset($pageCta)) { ?>
+                <?php if (!empty($pageCta['link'])) { ?>
                     <!-- floating cta -->
                     <div class="content__floating-cta">
                         <a href="<?= $pageCta['link'] ?>" class="cta"><?= $pageCta['label'] ?></a>


### PR DESCRIPTION
Object is created, and therefore showing an empty CTA. Verifying that the link itself is not empty.